### PR TITLE
docs: autocrlf false docker windows installation

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -65,6 +65,10 @@ Make sure that **Use Docker Compose V2** option is **unchecked** to avoid potent
 ## Cartoview Installation
 
 ### Running Cartoview Docker Services
+Before cloning the repository you sould set `autocrlf` to `false` because scripts.sh should use Unix-style line endings instead of Windows:
+```shell
+git config --global core.autocrlf false
+```
 Download **cartoview-1.33.0** by cloning the repository and using the tag **v1.33.0**.
 
 ```shell


### PR DESCRIPTION
When `docker-compose build --no-cache` 
error :
[4/5] RUN /usr/src/carto_app/cartoview/scripts/docker/setup.sh
/usr/src/carto_app/cartoview/scripts/docker/setup.sh no such a file

solution is to set autocrlf to false because the /docker/setup.sh script is Unix-style line endings instead of Windows.
```shell
git config --global core.autocrlf false
```

Windows 11
Docker 4.7.1 (77678) 